### PR TITLE
Add PHP backend for original contact form

### DIFF
--- a/original/index.html
+++ b/original/index.html
@@ -804,7 +804,7 @@
                                         <p class="text-sm text-muted-foreground">Fill out the form below and we'll get back to you with a customized proposal.</p>
                                     </div>
                                     <div class="p-6 pt-0">
-                                        <form class="space-y-6">
+                                        <form class="space-y-6" action="process_form.php" method="POST">
                                             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                                                 <div class="space-y-2">
                                                     <label class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70" for="name">Full Name *</label>

--- a/original/process_form.php
+++ b/original/process_form.php
@@ -1,0 +1,34 @@
+<?php
+if ($_SERVER["REQUEST_METHOD"] === "POST") {
+    $name = htmlspecialchars(trim($_POST['name'] ?? ''));
+    $email = filter_var(trim($_POST['email'] ?? ''), FILTER_SANITIZE_EMAIL);
+    $company = htmlspecialchars(trim($_POST['company'] ?? ''));
+    $phone = htmlspecialchars(trim($_POST['phone'] ?? ''));
+    $service = htmlspecialchars(trim($_POST['budget'] ?? ''));
+    $message = htmlspecialchars(trim($_POST['message'] ?? ''));
+
+    $to = "contact@example.com"; // TODO: change to your email address
+    $subject = "Nuevo mensaje de $name";
+    $body = "Nombre: $name\n" .
+            "Email: $email\n" .
+            "Empresa: $company\n" .
+            "Teléfono: $phone\n" .
+            "Servicio: $service\n\n" .
+            "Mensaje:\n$message";
+    $headers = "From: $email\r\nReply-To: $email";
+
+    $sent = false;
+    if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $sent = mail($to, $subject, $body, $headers);
+    }
+
+    if ($sent) {
+        echo "<h1>Gracias, $name!</h1><p>Tu mensaje ha sido enviado correctamente.</p>";
+    } else {
+        echo "<h1>Error</h1><p>No se pudo enviar tu mensaje. Inténtalo nuevamente más tarde.</p>";
+    }
+} else {
+    header("Location: index.html");
+    exit;
+}
+?>


### PR DESCRIPTION
## Summary
- connect original form to PHP endpoint
- add `process_form.php` to sanitize input and send email

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: A `require()` style import is forbidden, no-empty-object-type)*

------
https://chatgpt.com/codex/tasks/task_e_6893a331bb18833198d9cd9b6e9d8ab9