### PR TITLE
Add advertising campaigns page and link

### DIFF
--- a/original/campanas.html
+++ b/original/campanas.html
@@ -1,0 +1,127 @@
+<html lang="es">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Campañas Publicitarias - Versyl</title>
+        <link rel="stylesheet" crossorigin href="styles.css" />
+    </head>
+    <body>
+        <div id="root">
+            <div class="min-h-screen">
+                <header class="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-lg border-b border-border">
+                    <div class="container mx-auto px-4 py-4">
+                        <div class="flex items-center justify-between">
+                            <div class="flex items-center space-x-2">
+                                <span class="text-xl font-bold text-primary">Versyl</span>
+                            </div>
+                            <nav class="hidden md:flex items-center space-x-8">
+                                <a href="index.html#home" class="text-foreground hover:text-primary transition-colors">Inicio</a>
+                                <a href="index.html#services" class="text-foreground hover:text-primary transition-colors">Servicios</a>
+                                <a href="index.html#awards" class="text-foreground hover:text-primary transition-colors">Premios</a>
+                                <a href="index.html#testimonials" class="text-foreground hover:text-primary transition-colors">Reseñas</a>
+                                <a href="index.html#contact" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">Contacto</a>
+                            </nav>
+                        </div>
+                    </div>
+                </header>
+
+                <main class="pt-28 pb-20">
+                    <section class="container mx-auto px-4 space-y-16">
+                        <div class="text-center space-y-6">
+                            <h1 class="text-4xl font-bold text-foreground">Campañas de Publicidad Basadas en Datos que Impulsan Resultados</h1>
+                            <p class="text-lg text-muted-foreground max-w-3xl mx-auto">
+                                En la economía digital actual, la atención de los usuarios es el recurso más escaso. Nuestro servicio de Advertising Campaigns está diseñado para captar esa atención en el momento exacto y en el canal adecuado, transformando clics en ingresos medibles y sostenibles.
+                            </p>
+                        </div>
+
+                        <div class="space-y-8">
+                            <h2 class="text-3xl font-semibold text-foreground">Cómo Funciona Paso a Paso</h2>
+                            <div class="space-y-8">
+                                <div>
+                                    <h3 class="text-2xl font-semibold mb-2">1. Análisis de Mercado y Definición de Público Objetivo</h3>
+                                    <p class="text-muted-foreground">Antes de invertir un solo euro, realizamos un estudio exhaustivo de tu mercado, analizando tendencias de búsqueda, comportamientos de compra y datos demográficos. Con herramientas de first‑party data, audiencias look‑alike y paneles de inteligencia competitiva, trazamos un perfil detallado de tu cliente ideal.</p>
+                                </div>
+                                <div>
+                                    <h3 class="text-2xl font-semibold mb-2">2. Arquitectura de Campañas Omnicanal</h3>
+                                    <p class="text-muted-foreground">Diseñamos una arquitectura de campañas coherente en todas las plataformas clave—Google Ads, Meta (Facebook & Instagram), LinkedIn, TikTok, X, y redes programáticas—de modo que cada impacto contribuya a un embudo de conversión integrado. Esta sinergia inter‑plataforma incrementa la frecuencia de impacto cualificado sin inflar el presupuesto.</p>
+                                </div>
+                                <div>
+                                    <h3 class="text-2xl font-semibold mb-2">3. Desarrollo Creativo y Mensajes Personalizados</h3>
+                                    <p class="text-muted-foreground">Nuestro equipo creativo elabora anuncios dinámicos que se adaptan en tiempo real al contexto del usuario (sector, dispositivo, etapa del funnel). Combinamos copy persuasivo, visuales de alta resolución y motion graphics optimizados para cada canal.</p>
+                                </div>
+                                <div>
+                                    <h3 class="text-2xl font-semibold mb-2">4. Implementación Técnica y Etiquetado</h3>
+                                    <p class="text-muted-foreground">Configuramos píxeles, conversion APIs y eventos personalizados para asegurar un seguimiento granular de cada acción del usuario. Integramos Google Tag Manager y servidores de tags para minimizar la pérdida de datos debido a bloqueadores o restricciones de cookies.</p>
+                                </div>
+                                <div>
+                                    <h3 class="text-2xl font-semibold mb-2">5. Lanzamiento Controlado y Calibración Inicial</h3>
+                                    <p class="text-muted-foreground">Iniciamos las campañas con presupuestos piloto y audiencias segmentadas para validar supuestos. Monitorizamos indicadores críticos (CTR, CPC, tasa de conversión) y ajustamos creatividades, pujas y segmentaciones durante las primeras 72 h.</p>
+                                </div>
+                                <div>
+                                    <h3 class="text-2xl font-semibold mb-2">6. Optimización Continua Impulsada por IA</h3>
+                                    <p class="text-muted-foreground">Aplicamos machine learning propietario que analiza millones de combinaciones de anuncios y segmentaciones para identificar los patrones de mayor rendimiento. Ejecutamos test A/B y multivariante de manera continua y redistribuimos el presupuesto hacia los conjuntos de anuncios con mejor ROAS.</p>
+                                </div>
+                                <div>
+                                    <h3 class="text-2xl font-semibold mb-2">7. Reporting Transparente y Aprendizaje Iterativo</h3>
+                                    <p class="text-muted-foreground">Accede a un dashboard en tiempo real con métricas clave —ROAS, CPA, LTV, embudo por plataforma— y comentarios accionables de nuestros especialistas cada semana. Cerramos el ciclo con reuniones quincenales de insights para alinear learnings y escalar nuevas oportunidades.</p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="space-y-8">
+                            <h2 class="text-3xl font-semibold text-foreground">Por Qué Somos los Mejores</h2>
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-left border-collapse">
+                                    <thead>
+                                        <tr>
+                                            <th class="border px-4 py-2">Ventaja Competitiva</th>
+                                            <th class="border px-4 py-2">Qué Significa para Ti</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td class="border px-4 py-2">Expertise Certificado Google Premier Partner, Meta Business Partner & LinkedIn Marketing Partner</td>
+                                            <td class="border px-4 py-2">Acceso anticipado a betas y soporte dedicado que mejora tu rendimiento un 12 % promedio</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="border px-4 py-2">Tecnología Propietaria de Optimización</td>
+                                            <td class="border px-4 py-2">Bid‑shading automático y segmentación predictiva que elevan tu ROAS sin incrementar presupuesto</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="border px-4 py-2">Equipo Sénior Multidisciplinar</td>
+                                            <td class="border px-4 py-2">Estrategas, creativos y data scientists colaborando para darte una visión 360°</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="border px-4 py-2">Modelo de Honorarios Basado en Éxito</td>
+                                            <td class="border px-4 py-2">Solo crecemos si tu ROI crece; 0 % de fees sobre inversión inactiva</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="border px-4 py-2">Agilidad y Transparencia</td>
+                                            <td class="border px-4 py-2">Entregables claros, sin cláusulas de permanencia y con la data 100 % a tu nombre</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+
+                        <div class="space-y-8">
+                            <h2 class="text-3xl font-semibold text-foreground">Resultados que Hablan por Sí Solos</h2>
+                            <ul class="list-disc ml-6 space-y-2 text-muted-foreground">
+                                <li>ROAS medio de 4,7× a lo largo de 2024 en clientes de e‑commerce.</li>
+                                <li>Reducción del CPA en un 38 % tras 90 días de optimización continua.</li>
+                                <li>Más de 120 000 leads cualificados generados para empresas B2B de software.</li>
+                                <li>+212 % de ingresos para una marca de moda online en 6 meses (caso de estudio disponible bajo NDA).</li>
+                                <li>18 millones de impresiones de alta calidad con una tasa de viewability del 71 % en campañas programáticas.</li>
+                            </ul>
+                        </div>
+
+                        <div class="text-center pt-8">
+                            <p class="text-lg text-foreground font-semibold">¿Listo para multiplicar tu retorno publicitario? Ponte en contacto y descubre cómo nuestras campañas basadas en datos pueden transformar tu crecimiento digital.</p>
+                        </div>
+                    </section>
+                </main>
+            </div>
+        </div>
+    </body>
+</html>
+

--- a/original/index.html
+++ b/original/index.html
@@ -134,7 +134,8 @@
                                 <div class="flex flex-col space-y-1.5 p-6"><h3 class="tracking-tight text-xl font-semibold text-foreground group-hover:text-primary transition-colors">Campañas Publicitarias</h3></div>
                                 <div class="p-6 pt-0">
                                     <p class="text-sm text-muted-foreground mb-6 leading-relaxed">Genera tráfico dirigido y maximiza el ROI con campañas publicitarias basadas en datos en múltiples plataformas.</p>
-                                    <button
+                                    <a
+                                        href="campanas.html"
                                         class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2 w-full group-hover:bg-primary group-hover:text-primary-foreground transition-all duration-300"
                                     >
                                         + Info
@@ -153,7 +154,7 @@
                                             <path d="M5 12h14"></path>
                                             <path d="m12 5 7 7-7 7"></path>
                                         </svg>
-                                    </button>
+                                    </a>
                                 </div>
                             </div>
                             <div class="rounded-lg border text-card-foreground shadow-sm group hover:shadow-lg transition-all duration-300 hover:-translate-y-2 border-border/50 bg-card/80 backdrop-blur-sm">


### PR DESCRIPTION
## Summary
- Link the Campañas Publicitarias card in `original/index.html` to a new detailed page.
- Create `original/campanas.html` describing data-driven advertising campaigns with process, advantages, and results.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 3 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6893a6d721888331b75a3d2f23aa9541