### PR TITLE
Add SEO info page and link from services section

### DIFF
--- a/original/index.html
+++ b/original/index.html
@@ -213,7 +213,7 @@
                                 <div class="flex flex-col space-y-1.5 p-6"><h3 class="tracking-tight text-xl font-semibold text-foreground group-hover:text-primary transition-colors">SEO</h3></div>
                                 <div class="p-6 pt-0">
                                     <p class="text-sm text-muted-foreground mb-6 leading-relaxed">Aumenta tu visibilidad en línea y el tráfico orgánico con estrategias integrales de optimización para motores de búsqueda.</p>
-                                    <button
+                                    <a href="seo.html"
                                         class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none [&amp;_svg]:size-4 [&amp;_svg]:shrink-0 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2 w-full group-hover:bg-primary group-hover:text-primary-foreground transition-all duration-300"
                                     >
                                         + Info
@@ -232,7 +232,7 @@
                                             <path d="M5 12h14"></path>
                                             <path d="m12 5 7 7-7 7"></path>
                                         </svg>
-                                    </button>
+                                    </a>
                                 </div>
                             </div>
                               <div class="rounded-lg border text-card-foreground shadow-sm group hover:shadow-lg transition-all duration-300 hover:-translate-y-2 border-border/50 bg-card/80 backdrop-blur-sm">

--- a/original/seo.html
+++ b/original/seo.html
@@ -1,0 +1,126 @@
+<html lang="es">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>SEO Integral - Versyl</title>
+        <link rel="stylesheet" crossorigin href="styles.css" />
+    </head>
+    <body>
+        <div id="root">
+            <div class="min-h-screen">
+                <header class="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-lg border-b border-border">
+                    <div class="container mx-auto px-4 py-4">
+                        <div class="flex items-center justify-between">
+                            <div class="flex items-center space-x-2">
+                                <span class="text-xl font-bold text-primary">Versyl</span>
+                            </div>
+                            <nav class="hidden md:flex items-center space-x-8">
+                                <a href="index.html#home" class="text-foreground hover:text-primary transition-colors">Inicio</a>
+                                <a href="index.html#services" class="text-foreground hover:text-primary transition-colors">Servicios</a>
+                                <a href="index.html#awards" class="text-foreground hover:text-primary transition-colors">Premios</a>
+                                <a href="index.html#testimonials" class="text-foreground hover:text-primary transition-colors">Reseñas</a>
+                                <a href="index.html#contact" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">Contacto</a>
+                            </nav>
+                        </div>
+                    </div>
+                </header>
+
+                <main class="pt-28 pb-20">
+                    <section class="container mx-auto px-4 space-y-16">
+                        <div class="text-center space-y-6">
+                            <h1 class="text-4xl font-bold text-foreground">SEO Integral: Visibilidad Orgánica que Impulsa Tu Crecimiento</h1>
+                            <p class="text-lg text-muted-foreground max-w-3xl mx-auto">
+                                En un escenario digital saturado, aparecer en los primeros resultados de búsqueda es crítico para captar tráfico cualificado sin depender de la publicidad de pago. Nuestro servicio de SEO combina auditorías técnicas, estrategia de contenidos y autoridad de marca para incrementar tu visibilidad y multiplicar tus ingresos de forma sostenida.
+                            </p>
+                        </div>
+
+        <!-- STEP SECTION -->
+                        <div class="space-y-8">
+                            <h2 class="text-3xl font-semibold text-foreground">Cómo Funciona Paso a Paso</h2>
+                            <div class="space-y-8">
+                                <div>
+                                    <h3 class="text-2xl font-semibold mb-2">1. Auditoría Técnica y Research de Palabras Clave</h3>
+                                    <p class="text-muted-foreground">Realizamos un site audit 360° (crawl, indexación, Core Web Vitals, arquitectura, canibalizaciones) y un keyword research centrado en intención de búsqueda. Identificamos brechas de contenido y oportunidades de quick wins.</p>
+                                </div>
+                                <div>
+                                    <h3 class="text-2xl font-semibold mb-2">2. Optimización On‑Page &amp; Técnica</h3>
+                                    <p class="text-muted-foreground">Corregimos issues de rastreo (redirecciones, enlaces rotos, sitemap, robots), mejoramos estructura semántica (schema.org, headings) y potenciamos E‑E‑A‑T con señales de confianza (autores, referencias, políticas). Optimizamos Core Web Vitals para brindar velocidad y experiencia de usuario.</p>
+                                </div>
+                                <div>
+                                    <h3 class="text-2xl font-semibold mb-2">3. Estrategia de Contenidos</h3>
+                                    <p class="text-muted-foreground">Desarrollamos un content roadmap basado en clústeres temáticos y pirámide de intención. Producimos artículos, guías, vídeos y contenidos interactivos optimizados con NLP y enriquecidos con datos (FAQ, tablas, infografías).</p>
+                                </div>
+                                <div>
+                                    <h3 class="text-2xl font-semibold mb-2">4. Off‑Page y Link Building Ético</h3>
+                                    <p class="text-muted-foreground">Ejecutamos campañas de difusión y digital PR para obtener backlinks de alta autoridad (DR &gt; 60) y menciones relevantes. Monitorizamos perfiles de enlaces comparando con competidores para mantener un crecimiento saludable.</p>
+                                </div>
+                                <div>
+                                    <h3 class="text-2xl font-semibold mb-2">5. SEO Local e Internacional (opcional)</h3>
+                                    <p class="text-muted-foreground">Configuramos Google Business Profile, optimizamos citations y gestionamos reseñas. Para mercados globales, implementamos hreflang, geotargeting y estrategia de contenido multilingüe.</p>
+                                </div>
+                                <div>
+                                    <h3 class="text-2xl font-semibold mb-2">6. Monitorización, Reporting y Ajustes Continuos</h3>
+                                    <p class="text-muted-foreground">Integramos dashboards con Google Looker Studio y nuestra suite de datos propietaria. Medimos tráfico, rankings, clics, conversiones y calidad de enlaces. Aplicamos modelos de regresión para atribuir el impacto del SEO en el revenue.</p>
+                                </div>
+                            </div>
+                        </div>
+
+        <!-- POR QUE SOMOS LOS MEJORES -->
+                        <div class="space-y-8">
+                            <h2 class="text-3xl font-semibold text-foreground">Por Qué Somos los Mejores</h2>
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-left border-collapse">
+                                    <thead>
+                                        <tr>
+                                            <th class="border px-4 py-2">Ventaja Competitiva</th>
+                                            <th class="border px-4 py-2">Qué Significa para Ti</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td class="border px-4 py-2">Especialistas E‑E‑A‑T</td>
+                                            <td class="border px-4 py-2">Contenidos y señales que incrementan confianza y relevancia ante Google</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="border px-4 py-2">Tecnología Propietaria de Análisis</td>
+                                            <td class="border px-4 py-2">Crawler + ML que detecta oportunidades invisibles para herramientas estándar</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="border px-4 py-2">Equipo Multidisciplinar</td>
+                                            <td class="border px-4 py-2">SEOs técnicos, data scientists y periodistas colaboran para crear contenido ganador</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="border px-4 py-2">Metodología White‑Hat Certificada</td>
+                                            <td class="border px-4 py-2">Crecimiento sostenible, sin penalizaciones ni tácticas arriesgadas</td>
+                                        </tr>
+                                        <tr>
+                                            <td class="border px-4 py-2">Reporting Transparente en Tiempo Real</td>
+                                            <td class="border px-4 py-2">KPIs claros y accionables para tomar decisiones basadas en datos</td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+
+        <!-- RESULTADOS -->
+                        <div class="space-y-8">
+                            <h2 class="text-3xl font-semibold text-foreground">Resultados Contrastados</h2>
+                            <ul class="list-disc ml-6 space-y-2 text-muted-foreground">
+                                <li>Incremento medio del 112 % en tráfico orgánico año sobre año (2024).</li>
+                                <li>+62 % de palabras clave en top 3 tras 6 meses de optimización.</li>
+                                <li>Reducción del coste por lead en un 45 % frente a campañas de PPC equivalentes.</li>
+                                <li>ROI medio de 6,3× medido a 12 meses en e‑commerce B2C.</li>
+                                <li>Disminución del tiempo de carga a 0,9 s LCP mejorando la tasa de conversión en un 18 %.</li>
+                            </ul>
+                        </div>
+
+                        <div class="text-center pt-8">
+                            <p class="text-lg text-foreground font-semibold">¿Preparado para dominar los resultados de búsqueda y atraer tráfico cualificado día tras día? Contáctanos y elevemos tu visibilidad orgánica al siguiente nivel.</p>
+                        </div>
+                    </section>
+                </main>
+            </div>
+        </div>
+    </body>
+</html>
+


### PR DESCRIPTION
## Summary
- Replace the SEO service button with a link to a new SEO details page for easier navigation.
- Add a dedicated `seo.html` page describing the full SEO offering, including workflow, advantages, and performance metrics.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6893ab8c859c83318f13b1237ad57041